### PR TITLE
Feature: Replace Moq with NSubstitute

### DIFF
--- a/tests/Engines/Engine.ImagePngToJpgConverter.Tests/Engine.ImagePngToJpgConverter.Tests.csproj
+++ b/tests/Engines/Engine.ImagePngToJpgConverter.Tests/Engine.ImagePngToJpgConverter.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />

--- a/tests/Engines/Engine.ImagePngToJpgConverter.Tests/PngToJpgEngineTests.cs
+++ b/tests/Engines/Engine.ImagePngToJpgConverter.Tests/PngToJpgEngineTests.cs
@@ -75,11 +75,13 @@ namespace Engine.ImagePngToJpgConverter.Tests
             //Assert
             var jpgFilesLength = directoryInfo.GetFiles("*.jpg", SearchOption.AllDirectories).Length;
             var pngFilesLength = directoryInfo.GetFiles("*.png", SearchOption.AllDirectories).Length;
-
-            Assert.That(progress.PercentageComplete, Is.EqualTo(100));
-            Assert.That(progress.WorkDescription, Is.EqualTo("Compressing images from PNG to JPEG format finished"));
-            Assert.That(jpgFilesLength, Is.EqualTo(originalPngFilesLength));
-            Assert.That(pngFilesLength, Is.EqualTo(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(progress.PercentageComplete, Is.EqualTo(100));
+                Assert.That(progress.WorkDescription, Is.EqualTo("Compressing images from PNG to JPEG format finished"));
+                Assert.That(jpgFilesLength, Is.EqualTo(originalPngFilesLength));
+                Assert.That(pngFilesLength, Is.EqualTo(0));
+            });
         }
 
         [Test]

--- a/tests/SongsCompressor.MainManager.Tests/SongsCompressor.MainManager.Tests.csproj
+++ b/tests/SongsCompressor.MainManager.Tests/SongsCompressor.MainManager.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />


### PR DESCRIPTION
 As of Moq 4.20 it contains closed source that has exhibited behavior resembling that of malware:https://github.com/moq/moq/issues/1370